### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           NODE_ENV: production
       - name: Create CNAME
-        run: echo "jedutools.jbnu.ac.kr" > ./docs/CNAME
+        run: echo "jhelper.jbnu.ac.kr" > ./docs/CNAME
       - uses: peaceiris/actions-gh-pages@v2
         env:
           GITHUB_TOKEN: ${{ secrets.JHELPERTOKEN }}


### PR DESCRIPTION
jedutools.jbnu.ac.kr -> jhelper.jbnu.ac.kr 로 도메인 변경.

전북대 신청:
jedutools jhelper 도메인 모두 jbnu-jedutools.github.io 로 연결 신청. 외부 도메인 연결은 공문으로 진행.