### PR TITLE
docs(JHelper) : JHelpergettingStarted의  1.4.캐시정리 수정

### DIFF
--- a/content/JHelper/gettingStarted.mdx
+++ b/content/JHelper/gettingStarted.mdx
@@ -39,6 +39,7 @@ yarn install
 문서 변경사항이 제대로 반영되지 않거나 빌드 오류가 발생할 경우, 다음 명령어로 Gatsby 캐시를 정리할 수 있습니다.
 ```bash
 yarn clean
+yarn build
 ```
 
 ### 1.5. 개발 서버 실행


### PR DESCRIPTION
JHelper 시작하기 1.4.캐시정리 수정
yarn clean 이후 yarn build 해야 yarn develop 수행시에 오류가 뜨지않음.