### PR TITLE
style: 전역 표 스타일 개선 (헤더 배경·셀 여백·구분선·hover)

### DIFF
--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -76,16 +76,29 @@ export default {
     },
     table: {
       width: '100%',
-      borderCollapse: 'separate',
-      borderSpacing: 0
+      my: 4,
+      borderCollapse: 'collapse'
     },
     th: {
       textAlign: 'left',
-      borderBottomStyle: 'solid'
+      padding: '0.6rem 0.9rem',
+      backgroundColor: 'sidebar',
+      borderBottom: '2px solid',
+      borderColor: 'borderColor',
+      fontWeight: 'bold',
+      whiteSpace: 'nowrap'
     },
     td: {
       textAlign: 'left',
-      borderBottomStyle: 'solid'
+      padding: '0.6rem 0.9rem',
+      borderBottom: '1px solid',
+      borderColor: 'borderColor'
+    },
+    tr: {
+      transition: `background-color ${transition}`,
+      ':hover': {
+        backgroundColor: 'sidebar'
+      }
     }
   }
 };


### PR DESCRIPTION
- th에 연한 배경(sidebar 토큰)·굵은 글씨·2px 하단 구분선 추가
- td/th 셀 여백(0.6rem 0.9rem)으로 가독성 향상
- tr hover 시 행 강조 및 부드러운 전환
- borderCollapse: collapse 로 깔끔한 구분선
- 색상은 테마 토큰 사용 → 라이트/다크 등 전체 색상 모드 호환
- [수정 전]
<img width="1920" height="1211" alt="image" src="https://github.com/user-attachments/assets/9522b315-41bc-4275-abc9-22f2f885e0bc" />
-[수정후]
<img width="1920" height="1364" alt="image" src="https://github.com/user-attachments/assets/3d01f483-4add-487c-ad46-2bcd753d6144" />
